### PR TITLE
Add mandatory variable for project name

### DIFF
--- a/terraform/aws-account/account_admin_group.tf
+++ b/terraform/aws-account/account_admin_group.tf
@@ -3,11 +3,11 @@
 # terraform import aws_iam_group.account_admins AccountAdmins
 # ```
 resource "aws_iam_group" "account_admins" {
-  name = "AccountAdmins"
+  name = "${var.project_name}_AccountAdmins"
 }
 
 resource "aws_iam_group_membership" "account_admins" {
-  name = "account-admin-group-membership"
+  name = "${var.project_name}-account-admin-group-membership"
 
   users = [
     # TODO: add users here who can manage this AWS account

--- a/terraform/aws-account/account_admin_role.tf
+++ b/terraform/aws-account/account_admin_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "account_admin" {
-  name               = "AccountAdmin"
+  name               = "${var.project_name}_AccountAdmin"
   assume_role_policy = data.aws_iam_policy_document.assume_account_admin_role.json
 }
 
@@ -17,7 +17,7 @@ data "aws_iam_policy_document" "assume_account_admin_role" {
 }
 
 resource "aws_iam_policy" "allow_assume_account_admin_role" {
-  name = "AllowAssumeAccountAdminRole"
+  name = "${var.project_name}_AllowAssumeAccountAdminRole"
 
   policy = data.aws_iam_policy_document.allow_assume_account_admin_role.json
 }

--- a/terraform/aws-account/ecs.tf
+++ b/terraform/aws-account/ecs.tf
@@ -2,7 +2,7 @@
 # This defines needed policies and roles for ECS servies, tasks and containers
 
 resource "aws_iam_role" "ecsTaskExecutionRole" {
-  name               = "ecsTaskExecutionRole"
+  name               = "${var.project_name}_ecsTaskExecutionRole"
   description        = "Allows ECS tasks to call AWS services on your behalf."
   assume_role_policy = data.aws_iam_policy_document.assume_ecs_task_execution_role.json
 }

--- a/terraform/aws-account/infra_admin_group.tf
+++ b/terraform/aws-account/infra_admin_group.tf
@@ -3,11 +3,11 @@
 # terraform import aws_iam_group.infrastructure_admins InfraAdmins
 # ```
 resource "aws_iam_group" "infra_admins" {
-  name = "InfraAdmins"
+  name = "${var.project_name}_InfraAdmins"
 }
 
 resource "aws_iam_group_membership" "infra_admins" {
-  name = "infra-admin-group-membership"
+  name = "${var.project_name}_infra-admin-group-membership"
 
   users = [
     # TODO: add users here who can manage the infrastructure, but not the AWS account

--- a/terraform/aws-account/infra_admin_role.tf
+++ b/terraform/aws-account/infra_admin_role.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "infra_admin" {
-  name               = "InfraAdmin"
+  name               = "${var.project_name}_InfraAdmin"
   assume_role_policy = data.aws_iam_policy_document.assume_infra_admin_role.json
 }
 
@@ -44,31 +44,31 @@ resource "aws_iam_role_policy_attachment" "infra_admin_network_control" {
 }
 
 resource "aws_iam_policy" "allow_assume_infra_admin_role" {
-  name = "AllowAssumeInfraAdminRole"
+  name = "${var.project_name}_AllowAssumeInfraAdminRole"
 
   policy = data.aws_iam_policy_document.allow_assume_infra_admin_role.json
 }
 
 resource "aws_iam_policy" "allow_running_packer" {
-  name = "AllowRunningPacker"
+  name = "${var.project_name}_AllowRunningPacker"
 
   policy = data.aws_iam_policy_document.allow_running_packer.json
 }
 
 resource "aws_iam_policy" "allow_sops_updates" {
-  name = "AllowSopsUpdates"
+  name = "${var.project_name}_AllowSopsUpdates"
 
   policy = data.aws_iam_policy_document.allow_sops_updates.json
 }
 
 resource "aws_iam_policy" "infra_admin_machine_control" {
-  name = "InfraAdminMachineControl"
+  name = "${var.project_name}_InfraAdminMachineControl"
 
   policy = local.infra_admin_machine_control_merged_policy
 }
 
 resource "aws_iam_policy" "infra_admin_network_control" {
-  name = "InfraAdminNetworkControl"
+  name = "${var.project_name}_InfraAdminNetworkControl"
 
   policy = local.infra_admin_network_control_merged_policy
 }

--- a/terraform/aws-account/main.tf
+++ b/terraform/aws-account/main.tf
@@ -44,7 +44,7 @@ terraform {
 data "aws_caller_identity" "current" {}
 
 locals {
-  default_bucket_name = format("%s-terraform-backend", data.aws_caller_identity.current.account_id)
+  default_bucket_name = format("%s-%s-terraform-backend", data.aws_caller_identity.current.account_id, var.project_name)
 }
 
 resource "aws_s3_bucket" "terraform_bucket" {

--- a/terraform/aws-account/policies.tf
+++ b/terraform/aws-account/policies.tf
@@ -52,13 +52,13 @@ data "aws_iam_policy" "api_gateway_administrator" {
 }
 
 resource "aws_iam_policy" "allow_aws_account_terraform_state_access" {
-  name = "AllowAwsAccountTerraformStateAccess"
+  name = "${var.project_name}_AllowAwsAccountTerraformStateAccess"
 
   policy = data.aws_iam_policy_document.allow_aws_account_terraform_shared_state_access.json
 }
 
 resource "aws_iam_policy" "allow_infrastructure_terraform_state_access" {
-  name = "AllowInfrastructureTerraformStateAccess"
+  name = "${var.project_name}_AllowInfrastructureTerraformStateAccess"
 
   policy = data.aws_iam_policy_document.allow_infrastructure_terraform_shared_state_access.json
 }

--- a/terraform/aws-account/variables.tf
+++ b/terraform/aws-account/variables.tf
@@ -1,3 +1,7 @@
+variable "project_name" {
+  type        = string
+  description = "Project name to prefix or scope resources between multiple deployments based on this template."
+}
 
 variable "region" {
   type        = string


### PR DESCRIPTION
Add project name and use it to prefix resources to allow multiple project deployments to coexist under single AWS account.