### PR TITLE
Use weaker deletion protection for terraform state

### DIFF
--- a/terraform/aws-account/main.tf
+++ b/terraform/aws-account/main.tf
@@ -86,8 +86,8 @@ resource "aws_s3_bucket_object_lock_configuration" "terraform_bucket_object_lock
 
   rule {
     default_retention {
-      mode = "COMPLIANCE"
-      days = 5
+      mode = "GOVERNANCE" # If you want stronger protection use "COMPLIANCE"
+      days = 2
     }
   }
 }


### PR DESCRIPTION
Define deletion protection to hold the data for 2 days before deletion and use GOVERNANCE mode instead of COMPLIANCE. This allows user to with s3:BypassGovernanceRetention permissions to override the protection and delete all data. With COMPLIANCE, no-one can delete the data until the retention period has expired.